### PR TITLE
[bug] disclaimer background in dark mode is not dark in chromium

### DIFF
--- a/style.css
+++ b/style.css
@@ -248,7 +248,7 @@ body {
 /* Disclaimer and Info Cards */
 .disclaimer-card {
   border-left: 4px solid var(--error);
-  background-color: #fff5f5;
+  background-color: var(--bg-card);
 }
 
 .disclaimer-card .card-title {
@@ -266,7 +266,7 @@ body {
 
 .info-card {
   border-left: 4px solid var(--info);
-  background-color: #f0f9ff;
+  background-color: var(--bg-card);
 }
 
 .info-card .card-title {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated Disclaimer and Info cards to use the shared theme background variable instead of hardcoded light colors, keeping layout and borders unchanged for consistent appearance across themes and dark mode.
* **Tests**
  * Added a comprehensive CSS test suite to validate theme-aware styling, variable usage, accessibility, and regression checks.
* **Documentation**
  * Added test suite documentation describing coverage and how to run the CSS tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->